### PR TITLE
Increase result count in scrape.py to reduce api calls

### DIFF
--- a/python/scrape.py
+++ b/python/scrape.py
@@ -17,7 +17,7 @@ def get_tickers():
     all_tickers = []
 
     page_number = 1
-    per_page = 300
+    per_page = 3000
     while (True):
         body = {
             "instrumentType": "EXCHANGE_TRADED_FUND",


### PR DESCRIPTION
1 api call total, produces exact same output as previous code, a bit faster. Their end handles maxResultsPerPage > total_results_possible. 3000 includes everything, 5000 or greater would be more future-safe.